### PR TITLE
Add axes and showsIndicators to ScrollViewWithSitckyHeader's call for…

### DIFF
--- a/Sources/ScrollKit/ScrollViewWithStickyHeader.swift
+++ b/Sources/ScrollKit/ScrollViewWithStickyHeader.swift
@@ -99,7 +99,7 @@ private extension ScrollViewWithStickyHeader {
     
     var isStickyHeaderVisible: Bool {
         guard let headerMinHeight else { return headerVisibleRatio <= 0 }
-        return scrollOffset.y < -headerMinHeight
+        return scrollOffset.y < -(headerHeight - headerMinHeight)
     }
 
     @ViewBuilder

--- a/Sources/ScrollKit/ScrollViewWithStickyHeader.swift
+++ b/Sources/ScrollKit/ScrollViewWithStickyHeader.swift
@@ -115,7 +115,11 @@ private extension ScrollViewWithStickyHeader {
 
     var scrollView: some View {
         GeometryReader { proxy in
-            ScrollViewWithOffsetTracking(onScroll: handleScrollOffset) {
+            ScrollViewWithOffsetTracking(
+                axes,
+                showsIndicators: showsIndicators,
+                onScroll: handleScrollOffset
+            ) {
                 VStack(spacing: 0) {
                     scrollHeader
                     content()

--- a/Sources/ScrollKit/ScrollViewWithStickyHeader.swift
+++ b/Sources/ScrollKit/ScrollViewWithStickyHeader.swift
@@ -99,7 +99,8 @@ private extension ScrollViewWithStickyHeader {
     
     var isStickyHeaderVisible: Bool {
         guard let headerMinHeight else { return headerVisibleRatio <= 0 }
-        return scrollOffset.y < -(headerHeight - headerMinHeight)
+        return scrollOffset.y < -(headerHeight - (headerMinHeight / 2))
+//        return scrollOffset.y < -headerMinHeight
     }
 
     @ViewBuilder


### PR DESCRIPTION
Issue:
ScrollViewWithStickyHeader is not passing the arguments for 'axes' and 'showsIndicators' to 'ScrollViewWithOffsetTracking' when it calls it.

Fix:
Add 'axes' and 'showsIndicators' when calling 'ScrollViewWithOffsetTracking'