### PR TITLE
Add ScrollManager for programmatic control of ScrollViewWithStickyHeader

### DIFF
--- a/Demo/Demo/DemoScreen.swift
+++ b/Demo/Demo/DemoScreen.swift
@@ -48,7 +48,7 @@ struct DemoScreen<HeaderView: View>: View {
                 Button {
                     scrollManager.scrollToContent()
                 } label: {
-                    Label("Scroll to content", systemImage: "hand.point.up")
+                    Label("Scroll to content", systemImage: "hand.point.down")
                         .labelStyle(.iconOnly)
                 }
                 .buttonStyle(.plain)
@@ -57,7 +57,7 @@ struct DemoScreen<HeaderView: View>: View {
                 Button {
                     scrollManager.scrollToHeader()
                 } label: {
-                    Label("Scroll to header", systemImage: "hand.point.down")
+                    Label("Scroll to header", systemImage: "hand.point.up")
                         .labelStyle(.iconOnly)
                 }
                 .buttonStyle(.plain)

--- a/Demo/Demo/DemoScreen.swift
+++ b/Demo/Demo/DemoScreen.swift
@@ -25,11 +25,14 @@ struct DemoScreen<HeaderView: View>: View {
 
     @State
     private var scrollOffset: CGPoint = .zero
+    
+    private let scrollManager = ScrollManager()
 
     var body: some View {
         ScrollViewWithStickyHeader(
             header: header,
             headerHeight: headerHeight,
+            scrollManager: scrollManager,
             onScroll: handleScrollOffset
         ) {
             listItems
@@ -40,6 +43,24 @@ struct DemoScreen<HeaderView: View>: View {
                     .font(.headline)
                     .previewHeaderContent()
                     .opacity(1 - headerVisibleRatio)
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    scrollManager.scrollToContent()
+                } label: {
+                    Label("Scroll to content", systemImage: "hand.point.up")
+                        .labelStyle(.iconOnly)
+                }
+                .buttonStyle(.plain)
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    scrollManager.scrollToHeader()
+                } label: {
+                    Label("Scroll to header", systemImage: "hand.point.down")
+                        .labelStyle(.iconOnly)
+                }
+                .buttonStyle(.plain)
             }
         }
         .toolbarBackground(.hidden)

--- a/Sources/ScrollKit/Helpers/ScrollManager.swift
+++ b/Sources/ScrollKit/Helpers/ScrollManager.swift
@@ -1,0 +1,30 @@
+//
+//  ScrollViewOffsetTracker.swift
+//  ScrollKit
+//
+//  Created by Gabriel Ribeiro on 2025-04-06.
+//  Copyright © 2023-2024 Daniel Saidi. All rights reserved.
+//
+
+import SwiftUI
+
+final class ScrollManager: ObservableObject {
+    private var proxy: ScrollViewProxy?
+
+    func setProxy(_ proxy: ScrollViewProxy) {
+        self.proxy = proxy
+    }
+
+    func scrollToHeader(anchor: UnitPoint = .top) {
+        proxy?.scrollTo(ScrollTargets.header, anchor: anchor)
+    }
+
+    func scrollToContent(anchor: UnitPoint = .top) {
+        proxy?.scrollTo(ScrollTargets.content, anchor: anchor)
+    }
+}
+
+enum ScrollTargets {
+    static let header = "scrollkit-header"
+    static let content = "scrollkit-content"
+}

--- a/Sources/ScrollKit/Helpers/ScrollManager.swift
+++ b/Sources/ScrollKit/Helpers/ScrollManager.swift
@@ -1,5 +1,5 @@
 //
-//  ScrollViewOffsetTracker.swift
+//  ScrollManager.swift
 //  ScrollKit
 //
 //  Created by Gabriel Ribeiro on 2025-04-06.
@@ -8,23 +8,64 @@
 
 import SwiftUI
 
-final class ScrollManager: ObservableObject {
+/// A class that manages programmatic scrolling within a
+/// scroll view that uses sticky headers.
+///
+/// `ScrollManager` can be used to scroll to specific
+/// parts of a scroll view (e.g. the sticky header or
+/// the main content) using a `ScrollViewProxy`.
+///
+/// To use it, inject an instance into a compatible scroll
+/// view like `ScrollViewWithStickyHeader`, which will
+/// register its internal proxy with the manager on appear.
+///
+/// You can then call `scrollToHeader()` or
+/// `scrollToContent()` from your view model or UI logic
+/// to trigger animated scrolling actions.
+///
+/// - Important: `ScrollManager` uses `ScrollViewReader`
+///   under the hood, so the scrollable views must have
+///   valid `.id(...)` values matching the internal targets.
+public class ScrollManager: ObservableObject {
+
+    /// Creates a new scroll manager instance.
+    public init() { }
+
     private var proxy: ScrollViewProxy?
 
-    func setProxy(_ proxy: ScrollViewProxy) {
+    /// Scroll to the sticky header in the scroll view.
+    ///
+    /// - Parameter anchor: The anchor point to scroll to,
+    ///   defaulting to `.top`.
+    public func scrollToHeader(anchor: UnitPoint = .top) {
+        withAnimation {
+            proxy?.scrollTo(ScrollTargets.header, anchor: anchor)
+        }
+    }
+
+    /// Scroll to the main content in the scroll view.
+    ///
+    /// - Parameter anchor: The anchor point to scroll to,
+    ///   defaulting to `.top`.
+    public func scrollToContent(anchor: UnitPoint = .top) {
+        withAnimation {
+            proxy?.scrollTo(ScrollTargets.content, anchor: anchor)
+        }
+    }
+
+    /// Set the internal scroll proxy.
+    ///
+    /// This method is intended for internal use by views
+    /// like `ScrollViewWithStickyHeader`.
+    ///
+    /// - Parameter proxy: The `ScrollViewProxy` to store.
+    internal func setProxy(_ proxy: ScrollViewProxy) {
         self.proxy = proxy
     }
 
-    func scrollToHeader(anchor: UnitPoint = .top) {
-        proxy?.scrollTo(ScrollTargets.header, anchor: anchor)
+    /// Internal scroll target identifiers.
+    enum ScrollTargets {
+        static let header = "scrollkit-target-header"
+        static let content = "scrollkit-target-content"
     }
-
-    func scrollToContent(anchor: UnitPoint = .top) {
-        proxy?.scrollTo(ScrollTargets.content, anchor: anchor)
-    }
-}
-
-enum ScrollTargets {
-    static let header = "scrollkit-header"
-    static let content = "scrollkit-content"
 }

--- a/Sources/ScrollKit/Helpers/ScrollManager.swift
+++ b/Sources/ScrollKit/Helpers/ScrollManager.swift
@@ -26,7 +26,7 @@ import SwiftUI
 /// - Important: `ScrollManager` uses `ScrollViewReader`
 ///   under the hood, so the scrollable views must have
 ///   valid `.id(...)` values matching the internal targets.
-public class ScrollManager: ObservableObject {
+public class ScrollManager {
 
     /// Creates a new scroll manager instance.
     public init() { }

--- a/Sources/ScrollKit/ScrollViewWithStickyHeader.swift
+++ b/Sources/ScrollKit/ScrollViewWithStickyHeader.swift
@@ -71,11 +71,11 @@ public struct ScrollViewWithStickyHeader<Header: View, Content: View>: View {
     private let headerMinHeight: CGFloat?
     private let onScroll: ScrollAction?
     private let content: () -> Content
-
-    @ObservedObject private weak var scrollManager: ScrollManager?
-
+    
     public typealias ScrollAction = (_ offset: CGPoint, _ headerVisibleRatio: CGFloat) -> Void
 
+    private var scrollManager: ScrollManager?
+    
     @State
     private var navigationBarHeight: CGFloat = 0
 
@@ -127,19 +127,19 @@ private extension ScrollViewWithStickyHeader {
                 ) {
                     VStack(spacing: 0) {
                         scrollHeader
-                            .id(ScrollTargets.header)
+                            .id(ScrollManager.ScrollTargets.header)
                         content()
                             .frame(maxHeight: .infinity)
-                            .id(ScrollTargets.content)
+                            .id(ScrollManager.ScrollTargets.content)
                     }
+                }
+                .onAppear {
+                    scrollManager?.setProxy(scrollProxy)
                 }
             }
             .onAppear {
                 DispatchQueue.main.async {
                     navigationBarHeight = proxy.safeAreaInsets.top
-                }
-                .onAppear {
-                    scrollManager?.setProxy(scrollProxy)
                 }
             }
         }


### PR DESCRIPTION
### Summary

This PR introduces a `ScrollManager` class that enables programmatic scrolling within `ScrollViewWithStickyHeader`. It allows external code (e.g., view models or UI interactions) to scroll to the sticky header or the main content.

### Key Changes

- Added `ScrollManager` with `scrollToHeader()` and `scrollToContent()` APIs.
- Updated `ScrollViewWithStickyHeader` to optionally accept a `ScrollManager` and register its internal `ScrollViewProxy`.
- Added `.id(...)` identifiers to the header and content views for `ScrollViewReader` compatibility.
- Maintained full backward compatibility — if no `ScrollManager` is passed, the behavior is unchanged.

### Example Usage

![Simulator Screen Recording - iPhone 16 Pro - 2025-04-07 at 18 47 00](https://github.com/user-attachments/assets/368935d4-5861-4e64-a18c-8dcdc4d025ab)


```swift
private var scrollManager = ScrollManager()

ScrollViewWithStickyHeader(
    scrollManager: scrollManager,
    header: { /* ... */ },
    content: { /* ... */ }
)

Button("Scroll to Header") {
    scrollManager.scrollToHeader()
}
```

### Motivation

I just wanted to programmatically show or hide the header!

Let me know if you'd like any changes, doc, tests... Happy to help!