### PR TITLE
Fix bug with SafeArea

### DIFF
--- a/Sources/ScrollKit/ScrollViewWithStickyHeader.swift
+++ b/Sources/ScrollKit/ScrollViewWithStickyHeader.swift
@@ -110,7 +110,7 @@ public struct ScrollViewWithStickyHeader<Header: View, Content: View>: View {
                 scrollView(in: geo)
                 navbarOverlay(in: geo)
             }
-            .edgesIgnoringSafeArea(.all)
+            .edgesIgnoringSafeArea(.top)
         }
         .prefersNavigationBarHidden()
         #if os(iOS)


### PR DESCRIPTION
This pull request fixes issue #32, where ignoring the bottom safe area breaks content positioning and keyboard handling.

I believe ignoring only the top safe area is sufficient, as headerMinHeight relies solely on the .top value.